### PR TITLE
chore: target Node.js 24 and refresh dependency specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Bump versions with the help of semantic versioning and pull requests labels.
 
 Voilà! That's your next version.
 
+
+## Requirements
+
+- Node.js 24 or newer
+
 ## Usage
 
     bump-version:
@@ -24,6 +29,8 @@ Voilà! That's your next version.
       steps:
       - name: Setup node
         uses: actions/setup-node@v4.0.1
+        with:
+          node-version: 24
 
       - name: Get next version
         uses: MiguelRipoll23/get-next-version@v3.0.0

--- a/action.yml
+++ b/action.yml
@@ -43,5 +43,5 @@ outputs:
     description: 'Next version to use for a new release'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,24 +9,24 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.10.1",
-        "@actions/github": "^6.0.0",
-        "semver": "^7.6.0"
+        "@actions/core": "latest",
+        "@actions/github": "latest",
+        "semver": "latest"
       },
       "devDependencies": {
-        "@types/node": "^20.12.7",
-        "@typescript-eslint/eslint-plugin": "^7.7.1",
-        "@typescript-eslint/parser": "^7.7.1",
-        "@vercel/ncc": "^0.38.1",
-        "eslint": "^8.57.0",
-        "eslint-plugin-github": "^4.10.2",
-        "eslint-plugin-jsonc": "^2.15.1",
-        "eslint-plugin-prettier": "^5.1.3",
-        "prettier": "^3.2.5",
-        "typescript": "^5.4.5"
+        "@types/node": "latest",
+        "@typescript-eslint/eslint-plugin": "latest",
+        "@typescript-eslint/parser": "latest",
+        "@vercel/ncc": "latest",
+        "eslint": "latest",
+        "eslint-plugin-github": "latest",
+        "eslint-plugin-jsonc": "latest",
+        "eslint-plugin-prettier": "latest",
+        "prettier": "latest",
+        "typescript": "latest"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -27,24 +27,24 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.10.1",
-    "@actions/github": "^6.0.0",
-    "semver": "^7.6.0"
+    "@actions/core": "latest",
+    "@actions/github": "latest",
+    "semver": "latest"
   },
   "devDependencies": {
-    "@types/node": "^20.12.7",
-    "@typescript-eslint/eslint-plugin": "^7.7.1",
-    "@typescript-eslint/parser": "^7.7.1",
-    "@vercel/ncc": "^0.38.1",
-    "eslint": "^8.57.0",
-    "eslint-plugin-github": "^4.10.2",
-    "eslint-plugin-jsonc": "^2.15.1",
-    "eslint-plugin-prettier": "^5.1.3",
-    "prettier": "^3.2.5",
-    "typescript": "^5.4.5"
+    "@types/node": "latest",
+    "@typescript-eslint/eslint-plugin": "latest",
+    "@typescript-eslint/parser": "latest",
+    "@vercel/ncc": "latest",
+    "eslint": "latest",
+    "eslint-plugin-github": "latest",
+    "eslint-plugin-jsonc": "latest",
+    "eslint-plugin-prettier": "latest",
+    "prettier": "latest",
+    "typescript": "latest"
   }
 }


### PR DESCRIPTION
### Motivation

- Move the GitHub Action and project to Node.js 24 and ensure dependency specifiers resolve to up-to-date releases when run in a permitted environment.

### Description

- Change the action runtime from `node20` to `node24` in `action.yml` so the action uses Node.js 24. 
- Bump the project engine requirement to `"node": ">=24"` in `package.json` to reflect the new minimum Node.js version. 
- Replace all direct `dependencies` and `devDependencies` version specifiers in `package.json` with the `latest` tag so installs target the newest published versions. 
- Update `package-lock.json` metadata to match the new dependency specifiers and engine requirement and add a `## Requirements` section and `node-version: 24` to the README usage example.

### Testing

- Ran `npm install --package-lock-only`, which completed successfully (with an `EBADENGINE` warning because the local runtime is older than Node 24). 
- Ran `npm run package` which succeeded and produced the compiled `dist/` artifacts. 
- Ran `git diff --check` which reported no problems. 
- Attempted `npm update`, which failed with a `403 Forbidden` from the npm registry in this environment so resolved package versions could not be refreshed from the registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf74766788327b0ce11477081db3a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased minimum Node.js version requirement from 20 to 24; developers must upgrade to continue using the project
  * Updated all project dependencies and development tools to their latest available versions to enhance compatibility and maintain code quality standards
  * Updated GitHub Action workflow to execute on Node.js 24 runtime, ensuring consistency with the updated minimum version requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->