### PR TITLE
Include "bug" in default patch labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ Voilà! That's your next version.
 
 ### Inputs
 
-| Name                      | Description                                                         | Default             |
-| ------------------------- | ------------------------------------------------------------------- | ------------------- |
-| github-token              | Token from GitHub Actions or a Personal Access Token                | github.token        |
-| channel                   | Target channel (alpha/beta/stable/custom) of the version            | stable              |
-| new-build-for-prerelease  | Create a new build if version name contains a prerelease identifier | true                |
-| pull_requests_base_branch | Base branch used during pull requests search                        | github.ref          |
-| major-labels              | Comma separated list of labels for major releases                   | breaking-change     |
-| minor-labels              | Comma separated list of labels for minor releases                   | feature,enhancement |
-| patch-labels              | Comma separated list of labels for patch releases                   | bugfix,dependencies |
+| Name                      | Description                                                         | Default                 |
+| ------------------------- | ------------------------------------------------------------------- | ----------------------- |
+| github-token              | Token from GitHub Actions or a Personal Access Token                | github.token            |
+| channel                   | Target channel (alpha/beta/stable/custom) of the version            | stable                  |
+| new-build-for-prerelease  | Create a new build if version name contains a prerelease identifier | true                    |
+| pull_requests_base_branch | Base branch used during pull requests search                        | github.ref              |
+| major-labels              | Comma separated list of labels for major releases                   | breaking-change         |
+| minor-labels              | Comma separated list of labels for minor releases                   | feature,enhancement     |
+| patch-labels              | Comma separated list of labels for patch releases                   | bug,bugfix,dependencies |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
 
   patch-labels:
     description: 'Comma separated list of labels for patch releases'
-    default: 'bugfix,dependencies'
+    default: 'bug,bugfix,dependencies'
 
 # Define your outputs here.
 outputs:


### PR DESCRIPTION
### Motivation
- Ensure PRs labeled `bug` are treated as patch releases by default and keep the action inputs documented defaults in sync.

### Description
- Update the `patch-labels` default in `action.yml` to `bug,bugfix,dependencies` and update the README inputs table to match.

### Testing
- Ran `npx prettier --write README.md action.yml` to format the edited files (succeeded) and ran `npm run format:check` which still reports a pre-existing formatting issue in `.github/dependabot.yml` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee490166408327ae2f39f0c649a40e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated input documentation formatting in README.

* **Chores**
  * Updated default `patch-labels` configuration to include "bug" label alongside "bugfix" and "dependencies".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->